### PR TITLE
Detect stack overflow

### DIFF
--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 use serde::Serialize;
 use std::fs;
 use std::path::{Path, PathBuf};
-use tera::{self, Context, Tera};
+pub use tera::{self, Context as TeraContext, Tera};
 
 const TEMPLATES_DIR: Dir = include_dir!("templates/rust");
 
@@ -39,8 +39,12 @@ struct CreateContract {
     name: String,
 }
 
+#[derive(Serialize)]
+pub struct EmptyContext {
+}
+
 pub fn new_contract<P: AsRef<Path>>(name: String, path: P, signal: &Signal) -> Result<()> {
-    let context = Context::from_serialize(&CreateContract { name: name.clone() })?;
+    let context = TeraContext::from_serialize(&CreateContract { name: name.clone() })?;
     // generate contract
     let path = path.as_ref().to_str().expect("path");
     let cmd = DockerCommand::with_config(DOCKER_IMAGE.to_string(), path.to_string())
@@ -77,7 +81,7 @@ fn gen_project_layout<P: AsRef<Path>>(name: String, project_path: P) -> Result<(
         fs::File::create(&dir_path)?;
     }
     // generate files
-    let context = Context::from_serialize(&CreateProject {
+    let context = TeraContext::from_serialize(&CreateProject {
         name: name.clone(),
         path: project_path.clone(),
     })?;
@@ -113,7 +117,7 @@ fn gen_project_test<P: AsRef<Path>>(name: String, project_path: P, signal: &Sign
         path
     };
     // initialize tests code
-    let context = Context::from_serialize(&CreateProject {
+    let context = TeraContext::from_serialize(&CreateProject {
         name: name.clone(),
         path: project_path.clone(),
     })?;

--- a/templates/rust/linker.ld
+++ b/templates/rust/linker.ld
@@ -1,0 +1,192 @@
+/* CKB-VM linker script */
+/* Each W ^ X page need to align to 4096 to make sure permission is correct */
+OUTPUT_FORMAT("elf64-littleriscv", "elf64-littleriscv",
+	      "elf64-littleriscv")
+OUTPUT_ARCH(riscv)
+ENTRY(_start)
+SEARCH_DIR("/riscv/riscv64-unknown-elf/lib");
+
+PROVIDE(_stack_start = 4096 * 1024);
+SECTIONS
+{
+  /* stack section */
+  _sstack = .;
+  /* round down stack size */
+  _stack_start = _stack_start / 4096 * 4096;
+  .stack     : ALIGN(8)
+  {
+    LONG(_stack_start);
+    . = _sstack + _stack_start;
+  }
+  _estack = .;
+  /* .data .bss */
+  . = ALIGN(4096);
+  .data           :
+  {
+    __DATA_BEGIN__ = .;
+    *(.data .data.* .gnu.linkonce.d.*)
+    SORT(CONSTRUCTORS)
+  }
+  .data1          : { *(.data1) }
+  .got            : { *(.got.plt) *(.igot.plt) *(.got) *(.igot) }
+  /* We want the small data sections together, so single-instruction offsets
+     can access them all, and initialized data all before uninitialized, so
+     we can shorten the on-disk segment size.  */
+  .sdata          :
+  {
+    __SDATA_BEGIN__ = .;
+    *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2) *(.srodata .srodata.*)
+    *(.sdata .sdata.* .gnu.linkonce.s.*)
+  }
+  _edata = .; PROVIDE (edata = .);
+  . = ALIGN(4096);
+  __bss_start = .;
+  .sbss           : ALIGN(8)
+  {
+    *(.dynsbss)
+    *(.sbss .sbss.* .gnu.linkonce.sb.*)
+    *(.scommon)
+  }
+  .bss            : ALIGN(8)
+  {
+   *(.dynbss)
+   *(.bss .bss.* .gnu.linkonce.b.*)
+   *(COMMON)
+   /* Align here to ensure that the .bss section occupies space up to
+      _end.  Align after .bss to ensure correct alignment even if the
+      .bss section disappears because there are no input sections.
+      FIXME: Why do we need it? When there is no .bss section, we do not
+      pad the .data section.  */
+   . = ALIGN(. != 0 ? 64 / 8 : 1);
+  }
+  . = ALIGN(64 / 8);
+  . = SEGMENT_START("ldata-segment", .);
+  . = ALIGN(64 / 8);
+  __BSS_END__ = .;
+    __global_pointer$ = MIN(__SDATA_BEGIN__ + 0x800,
+		            MAX(__DATA_BEGIN__ + 0x800, __BSS_END__ - 0x800));
+  _end = .; PROVIDE (end = .);
+  . = ALIGN(4096);
+  /* Read-only sections, merged into text segment: */
+  PROVIDE (__executable_start = . );
+  .interp         : { *(.interp) } 
+  .note.gnu.build-id  : { *(.note.gnu.build-id) }
+  .hash           : { *(.hash) }
+  .gnu.hash       : { *(.gnu.hash) }
+  .dynsym         : { *(.dynsym) }
+  .dynstr         : { *(.dynstr) }
+  .gnu.version    : { *(.gnu.version) }
+  .gnu.version_d  : { *(.gnu.version_d) }
+  .gnu.version_r  : { *(.gnu.version_r) }
+  .rela.init      : { *(.rela.init) }
+  .rela.text      : { *(.rela.text .rela.text.* .rela.gnu.linkonce.t.*) }
+  .rela.fini      : { *(.rela.fini) }
+  .rela.rodata    : { *(.rela.rodata .rela.rodata.* .rela.gnu.linkonce.r.*) }
+  .rela.data.rel.ro   : { *(.rela.data.rel.ro .rela.data.rel.ro.* .rela.gnu.linkonce.d.rel.ro.*) }
+  .rela.data      : { *(.rela.data .rela.data.* .rela.gnu.linkonce.d.*) }
+  .rela.tdata	  : { *(.rela.tdata .rela.tdata.* .rela.gnu.linkonce.td.*) }
+  .rela.tbss	  : { *(.rela.tbss .rela.tbss.* .rela.gnu.linkonce.tb.*) }
+  .rela.ctors     : { *(.rela.ctors) }
+  .rela.dtors     : { *(.rela.dtors) }
+  .rela.got       : { *(.rela.got) }
+  .rela.sdata     : { *(.rela.sdata .rela.sdata.* .rela.gnu.linkonce.s.*) }
+  .rela.sbss      : { *(.rela.sbss .rela.sbss.* .rela.gnu.linkonce.sb.*) }
+  .rela.sdata2    : { *(.rela.sdata2 .rela.sdata2.* .rela.gnu.linkonce.s2.*) }
+  .rela.sbss2     : { *(.rela.sbss2 .rela.sbss2.* .rela.gnu.linkonce.sb2.*) }
+  .rela.bss       : { *(.rela.bss .rela.bss.* .rela.gnu.linkonce.b.*) }
+  .rela.iplt      :
+    {
+      PROVIDE_HIDDEN (__rela_iplt_start = .);
+      *(.rela.iplt)
+      PROVIDE_HIDDEN (__rela_iplt_end = .);
+    }
+  .rela.plt       :
+    {
+      *(.rela.plt)
+    }
+  .init           :
+  {
+    KEEP (*(SORT_NONE(.init)))
+  }
+  .plt            : { *(.plt) }
+  .iplt           : { *(.iplt) }
+  . = ALIGN(4096);
+  .text           :
+  {
+    *(.text.unlikely .text.*_unlikely .text.unlikely.*)
+    *(.text.exit .text.exit.*)
+    *(.text.startup .text.startup.*)
+    *(.text.hot .text.hot.*)
+    *(.text .stub .text.* .gnu.linkonce.t.*)
+    /* .gnu.warning sections are handled specially by elf32.em.  */
+    *(.gnu.warning)
+  } 
+  . = ALIGN(4096);
+  .fini           :
+  {
+    KEEP (*(SORT_NONE(.fini)))
+  }
+  PROVIDE (__etext = .);
+  PROVIDE (_etext = .);
+  PROVIDE (etext = .);
+  .rodata         : ALIGN(8) { *(.rodata .rodata.* .gnu.linkonce.r.*) } 
+  .rodata1        : ALIGN(8) { *(.rodata1) } 
+  .sdata2         :
+  {
+    *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
+  }
+  .sbss2          : { *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*) }
+  .eh_frame_hdr   : { *(.eh_frame_hdr) *(.eh_frame_entry .eh_frame_entry.*) }
+  .eh_frame       : ONLY_IF_RO { KEEP (*(.eh_frame)) *(.eh_frame.*) } 
+  .gcc_except_table   : ONLY_IF_RO { *(.gcc_except_table .gcc_except_table.*) }
+  .gnu_extab   : ONLY_IF_RO { *(.gnu_extab*) }
+  /* Exception handling  */
+  .eh_frame       : ONLY_IF_RW { KEEP (*(.eh_frame)) *(.eh_frame.*) } 
+  .gnu_extab      : ONLY_IF_RW { *(.gnu_extab) }
+  .gcc_except_table   : ONLY_IF_RW { *(.gcc_except_table .gcc_except_table.*) }
+  .exception_ranges   : ONLY_IF_RW { *(.exception_ranges*) }
+  . = ALIGN(4096);
+  /* Stabs debugging sections.  */
+  .stab          0 : { *(.stab) } 
+  .stabstr       0 : { *(.stabstr) }
+  .stab.excl     0 : { *(.stab.excl) }
+  .stab.exclstr  0 : { *(.stab.exclstr) }
+  .stab.index    0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment       0 : { *(.comment) }
+  .gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  /* DWARF Extension.  */
+  .debug_macro    0 : { *(.debug_macro) }
+  .debug_addr     0 : { *(.debug_addr) }
+  .gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+  /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
+}
+


### PR DESCRIPTION
Since CKB-VM has no MMU(Instead the CKB-VM has a W^X solution: [link](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0003-ckb-vm/0003-ckb-vm.md#wx-memory)), if a program's stack grows too much, the data of `heap` / `.bss` will be corrupted.

A solution([inherited from cortex-m-rt](https://github.com/rust-embedded/cortex-m-rt/issues/34)) is to re-order the sections of the program, instead of putting the stack at the end of memory, we can put it at the beginning, if the stack grows down too much, the program tries to read address lower than zero, then the VM raises an InvalidPermission error.

I tried this solution, but stuck by an issue: In the generated binary, the `.stack` is in a `R E` segment, which I want is `R W`, I have tried to use `MEMORY` command to manually set flags on the segment, but it doesn't work.

To reproduce, just run `capsule new demo; cd demo; capsule build;`, then inspect the binary `riscv64-unknown-elf-readelf -l build/debug/demo`;

[linker script](https://github.com/jjyr/capsule/blob/detect-stack-overflow/templates/rust/linker.ld)

Need help.