### PR TITLE
fix: change codegen-units value to fix invalid binary built with release mode

### DIFF
--- a/templates/Cargo-manifest.toml
+++ b/templates/Cargo-manifest.toml
@@ -5,5 +5,5 @@ members = ["tests"]
 overflow-checks = true
 opt-level = 's'
 lto = true
-codegen-units = 1
+codegen-units = 2
 panic = 'abort'


### PR DESCRIPTION
@jordanmack 
> I'm having a strange problem with a script I'm working on. It seems like the debug version is fine, but the release version might be broken. Using capsule test all the tests run fine with the debug version. Using capsule test --release all the tests failed. Using a different script, both worked just fine. Do you have any suggestion on how to debug this?

> https://github.com/jordanmack/token-buy-lock

> I've been experimenting with changing the profile.release flags in Cargo.toml, with some luck. Changing the opt-level, lto, and codegen-units values sometimes produces a working release binary. So far, increasing codegen-units to 2 seems to be the best combination for producing a small and functional release binary.

Tested with `rust nightly 2021-06-09`, the same error. I suspect it's a bug of `ckb-vm` or `rustc`.

**NOTE**: this is a workaround fix, should investigate it by looking at the assembly code.