### PR TITLE
Support `capsule build --release --debug-info`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ checksum = "027dcb7d0c770d6a7e99cb63e51762f1c6952828f1d01d13f9f044c40a174aee"
 
 [[package]]
 name = "ckb-capsule"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-capsule"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Nervos Network"]
 edition = "2018"
 license = "MIT"

--- a/src/bin/capsule.rs
+++ b/src/bin/capsule.rs
@@ -88,9 +88,11 @@ fn run_cli() -> Result<()> {
         .subcommand(SubCommand::with_name("check").about("Check environment and dependencies").display_order(0))
         .subcommand(SubCommand::with_name("new").about("Create a new project").args(&contract_args).display_order(1))
         .subcommand(SubCommand::with_name("new-contract").about("Create a new contract").args(&contract_args).display_order(2))
-        .subcommand(SubCommand::with_name("build").about("Build contracts").arg(Arg::with_name("name").short("n").long("name").multiple(true).takes_value(true).help("contract name")).arg(
-                    Arg::with_name("release").long("release").help("Build contracts in release mode.")
-        ).arg(Arg::with_name("debug-output").long("debug-output").help("Always enable debugging output")).display_order(3))
+        .subcommand(SubCommand::with_name("build").about("Build contracts")
+            .arg(Arg::with_name("name").short("n").long("name").multiple(true).takes_value(true).help("contract name"))
+            .arg(Arg::with_name("release").long("release").help("Build contracts in release mode."))
+                .args(&[Arg::with_name("debug-output").long("debug-output").help("Always enable debugging output").display_order(3),
+                        Arg::with_name("debug-info").long("debug-info").help("Always generate debug information, using -g flag, which is an alias for -C debuginfo=2").display_order(3)]))
         .subcommand(SubCommand::with_name("run").about("Run command in contract build image").usage("ckb_capsule run --name <name> 'echo list contract dir: && ls'")
         .args(&[Arg::with_name("name").short("n").long("name").required(true).takes_value(true).help("contract name"),
                 Arg::with_name("cmd").required(true).multiple(true).help("command to run")])
@@ -257,9 +259,11 @@ fn run_cli() -> Result<()> {
                 BuildEnv::Debug
             };
             let always_debug = args.is_present("debug-output");
+            let debug_info = args.is_present("debug-info");
             let build_config = BuildConfig {
                 build_env,
                 always_debug,
+                debug_info,
             };
 
             let contracts: Vec<_> = select_contracts(&context, &build_names);

--- a/src/project_context.rs
+++ b/src/project_context.rs
@@ -36,6 +36,7 @@ impl FromStr for BuildEnv {
 pub struct BuildConfig {
     pub build_env: BuildEnv,
     pub always_debug: bool,
+    pub debug_info: bool
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/recipe/rust.rs
+++ b/src/recipe/rust.rs
@@ -19,7 +19,9 @@ const RUST_TARGET: &str = "riscv64imac-unknown-none-elf";
 const CARGO_CONFIG_PATH: &str = ".cargo/config";
 const BASE_RUSTFLAGS: &str =
     "-Z pre-link-arg=-zseparate-code -Z pre-link-arg=-zseparate-loadable-segments";
-const RELEASE_RUSTFLAGS: &str = "-C link-arg=-s";
+const RELEASE_RUSTFLAGS: &str = "";
+/// strip binaries making executables much smaller often
+const STRIP_RUSTFLAG: &str = "-C link-arg=-s";
 const ALWAYS_DEBUG_RUSTFLAGS: &str = "--cfg=debug_assertions";
 
 pub struct Rust {
@@ -57,7 +59,7 @@ impl Rust {
             _ if has_cargo_config => "".to_string(),
             BuildEnv::Debug => format!("RUSTFLAGS=\"{}\"", BASE_RUSTFLAGS.to_string()),
             BuildEnv::Release => {
-                let mut args = String::from(format!("RUSTFLAGS=\"{} ", BASE_RUSTFLAGS));
+                let mut args = String::from(format!("RUSTFLAGS=\"{} {} ", BASE_RUSTFLAGS, RELEASE_RUSTFLAGS));
                 if config.always_debug {
                     args.push_str(&format!("{} ", ALWAYS_DEBUG_RUSTFLAGS));
                 }
@@ -67,7 +69,7 @@ impl Rust {
                     // which will generate full debug info
                     args.push_str("-g ");
                 } else {
-                    args.push_str(&format!("{} ", RELEASE_RUSTFLAGS));
+                    args.push_str(&format!("{} ", STRIP_RUSTFLAG));
                 }
                 args.push('\"');
                 args

--- a/src/recipe/rust.rs
+++ b/src/recipe/rust.rs
@@ -57,14 +57,20 @@ impl Rust {
             _ if has_cargo_config => "".to_string(),
             BuildEnv::Debug => format!("RUSTFLAGS=\"{}\"", BASE_RUSTFLAGS.to_string()),
             BuildEnv::Release => {
+                let mut args = String::from(format!("RUSTFLAGS=\"{} ", BASE_RUSTFLAGS));
                 if config.always_debug {
-                    format!(
-                        "RUSTFLAGS=\"{} {} {}\"",
-                        BASE_RUSTFLAGS, RELEASE_RUSTFLAGS, ALWAYS_DEBUG_RUSTFLAGS
-                    )
-                } else {
-                    format!("RUSTFLAGS=\"{} {}\"", BASE_RUSTFLAGS, RELEASE_RUSTFLAGS)
+                    args.push_str(&format!("{} ", ALWAYS_DEBUG_RUSTFLAGS));
                 }
+                if config.debug_info {
+                    // https://doc.rust-lang.org/rustc/codegen-options/index.html#debuginfo
+                    // The `-g` flag is an alias for -C debuginfo=2,
+                    // which will generate full debug info
+                    args.push_str("-g ");
+                } else {
+                    args.push_str(&format!("{} ", RELEASE_RUSTFLAGS));
+                }
+                args.push('\"');
+                args
             }
         }
     }


### PR DESCRIPTION
Use `--debug-info` arg to generate full debug info.

## Example
$ godwoken-scripts >
capsule build --release --debug-output --debug-info