### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/recipe/c.rs
+++ b/src/recipe/c.rs
@@ -218,7 +218,8 @@ impl<R: CRecipe> Recipe for C<R> {
         // copy to build dir
         if !bin_path.exists() {
             return Err(anyhow!(
-                "can't find contract binary from path {:?}, please check Makefile"
+                "can't find contract binary from path {:?}, please check Makefile",
+                bin_path,
             ));
         }
         let mut target_path = self.context.project_path.clone();


### PR DESCRIPTION
Without this, the error message would literally be "can't find contract binary from path {:?}, please check Makefile" with curly braces in it instead of the path.