### PR TITLE
Support proxy when build

### DIFF
--- a/src/bin/capsule.rs
+++ b/src/bin/capsule.rs
@@ -62,7 +62,7 @@ fn group_contracts_by_type(contracts: Vec<Contract>) -> HashMap<TemplateType, Ve
 
 fn get_last_args() -> (Vec<String>, Option<Vec<String>>) {
     let args: Vec<String> = env::args().collect();
-    let mut iter = args.split(|n| n == "--");
+    let mut iter = args.splitn(2, |n| n == "--");
     (iter.next().unwrap().to_vec(), {
         let next_iter = iter.next();
         if next_iter.is_none() || next_iter.unwrap().is_empty() {

--- a/src/bin/capsule.rs
+++ b/src/bin/capsule.rs
@@ -60,15 +60,17 @@ fn group_contracts_by_type(contracts: Vec<Contract>) -> HashMap<TemplateType, Ve
     contracts_by_type
 }
 
-fn get_last_args() -> (Vec<String>, Vec<String>) {
+fn get_last_args() -> (Vec<String>, Option<Vec<String>>) {
     let args: Vec<String> = env::args().collect();
-    for i in 0..args.len() {
-        if args[i] == "--" {
-            let args = args.split_at(i);
-            return (Vec::from(args.0), Vec::from(args.1.split_at(1).1));
+    let mut iter = args.split(|n| n == "--");
+    (iter.next().unwrap().to_vec(), {
+        let next_iter = iter.next();
+        if next_iter.is_none() || next_iter.unwrap().is_empty() {
+            Option::None
+        } else {
+            Option::Some(next_iter.unwrap().to_vec())
         }
-    }
-    (args, Vec::new())
+    })
 }
 
 fn run_cli() -> Result<()> {
@@ -287,12 +289,7 @@ fn run_cli() -> Result<()> {
                 for contract in contracts {
                     println!("Building contract {}", contract.name);
                     let recipe = get_recipe(context.clone(), contract.template_type)?;
-                    recipe.run_build(
-                        &contract,
-                        build_config,
-                        &signal,
-                        Option::Some(args_last.clone()),
-                    )?;
+                    recipe.run_build(&contract, build_config, &signal, args_last.clone())?;
                 }
                 println!("Done");
             }

--- a/src/bin/capsule.rs
+++ b/src/bin/capsule.rs
@@ -287,7 +287,12 @@ fn run_cli() -> Result<()> {
                 for contract in contracts {
                     println!("Building contract {}", contract.name);
                     let recipe = get_recipe(context.clone(), contract.template_type)?;
-                    recipe.run_build(&contract, build_config, &signal, Option::Some(args_last.clone()))?;
+                    recipe.run_build(
+                        &contract,
+                        build_config,
+                        &signal,
+                        Option::Some(args_last.clone()),
+                    )?;
                 }
                 println!("Done");
             }

--- a/src/bin/capsule.rs
+++ b/src/bin/capsule.rs
@@ -99,9 +99,14 @@ fn run_cli() -> Result<()> {
         .subcommand(SubCommand::with_name("check").about("Check environment and dependencies").display_order(0))
         .subcommand(SubCommand::with_name("new").about("Create a new project").args(&contract_args).display_order(1))
         .subcommand(SubCommand::with_name("new-contract").about("Create a new contract").args(&contract_args).display_order(2))
-        .subcommand(SubCommand::with_name("build").about("Build contracts").arg(Arg::with_name("name").short("n").long("name").multiple(true).takes_value(true).help("contract name")).arg(
-                    Arg::with_name("release").long("release").help("Build contracts in release mode.")
-        ).arg(Arg::with_name("debug-output").long("debug-output").help("Always enable debugging output")).display_order(3))
+        .subcommand(
+            SubCommand::with_name("build")
+                .about("Build contracts")
+                .arg(Arg::with_name("name").short("n").long("name").multiple(true).takes_value(true).help("contract name"))
+                .arg(Arg::with_name("release").long("release").help("Build contracts in release mode."))
+                .arg(Arg::with_name("debug-output").long("debug-output").help("Always enable debugging output"))
+                .arg(Arg::with_name("host").long("host").help("Docker runs in host mode"))
+                .display_order(3))
         .subcommand(SubCommand::with_name("run").about("Run command in contract build image").usage("ckb_capsule run --name <name> 'echo list contract dir: && ls'")
         .args(&[Arg::with_name("name").short("n").long("name").required(true).takes_value(true).help("contract name"),
                 Arg::with_name("cmd").required(true).multiple(true).help("command to run")])
@@ -258,7 +263,7 @@ fn run_cli() -> Result<()> {
             println!("Done");
         }
         ("build", Some(args)) => {
-            let context = Context::load()?;
+            let mut context = Context::load()?;
             let build_names: Vec<&str> = args
                 .values_of("name")
                 .map(|values| values.collect())
@@ -269,6 +274,7 @@ fn run_cli() -> Result<()> {
                 BuildEnv::Debug
             };
             let always_debug = args.is_present("debug-output");
+            context.use_docker_host = args.is_present("host");
             let build_config = BuildConfig {
                 build_env,
                 always_debug,

--- a/src/bin/capsule.rs
+++ b/src/bin/capsule.rs
@@ -60,17 +60,13 @@ fn group_contracts_by_type(contracts: Vec<Contract>) -> HashMap<TemplateType, Ve
     contracts_by_type
 }
 
-fn get_last_args() -> (Vec<String>, Option<Vec<String>>) {
+fn get_last_args() -> (Vec<String>, Vec<String>) {
     let args: Vec<String> = env::args().collect();
     let mut iter = args.splitn(2, |n| n == "--");
-    (iter.next().unwrap().to_vec(), {
-        let next_iter = iter.next();
-        if next_iter.is_none() || next_iter.unwrap().is_empty() {
-            Option::None
-        } else {
-            Option::Some(next_iter.unwrap().to_vec())
-        }
-    })
+    (
+        iter.next().unwrap().to_vec(),
+        iter.next().map(|f| f.to_vec()).unwrap_or(Vec::new()),
+    )
 }
 
 fn run_cli() -> Result<()> {
@@ -289,7 +285,12 @@ fn run_cli() -> Result<()> {
                 for contract in contracts {
                     println!("Building contract {}", contract.name);
                     let recipe = get_recipe(context.clone(), contract.template_type)?;
-                    recipe.run_build(&contract, build_config, &signal, args_last.clone())?;
+                    recipe.run_build(
+                        &contract,
+                        build_config,
+                        &signal,
+                        Option::Some(args_last.clone()),
+                    )?;
                 }
                 println!("Done");
             }

--- a/src/project_context.rs
+++ b/src/project_context.rs
@@ -60,6 +60,7 @@ impl FromStr for DeployEnv {
 pub struct Context {
     pub project_path: PathBuf,
     pub config: Config,
+    pub use_docker_host: bool,
 }
 
 impl Context {
@@ -88,6 +89,7 @@ impl Context {
         Ok(Context {
             config,
             project_path,
+            use_docker_host: false,
         })
     }
 

--- a/src/recipe/c.rs
+++ b/src/recipe/c.rs
@@ -208,7 +208,7 @@ impl<R: CRecipe> Recipe for C<R> {
         c: &Contract,
         config: BuildConfig,
         signal: &Signal,
-        _opt_cmd: Option<Vec<String>>,
+        _build_args_opt: Option<Vec<String>>,
     ) -> Result<()> {
         let build_target = self.build_target(config.build_env, &c.name);
         let mut bin_path = self.c_dir();

--- a/src/recipe/c.rs
+++ b/src/recipe/c.rs
@@ -203,7 +203,13 @@ impl<R: CRecipe> Recipe for C<R> {
 
     /// build contract
     /// Delegate to Makefile
-    fn run_build(&self, c: &Contract, config: BuildConfig, signal: &Signal) -> Result<()> {
+    fn run_build(
+        &self,
+        c: &Contract,
+        config: BuildConfig,
+        signal: &Signal,
+        _opt_cmd: Option<Vec<String>>,
+    ) -> Result<()> {
         let build_target = self.build_target(config.build_env, &c.name);
         let mut bin_path = self.c_dir();
         bin_path.push(&build_target);

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -28,7 +28,7 @@ pub trait Recipe {
         contract: &Contract,
         config: BuildConfig,
         signal: &Signal,
-        opt_cmd: Option<Vec<String>>,
+        build_args_opt: Option<Vec<String>>,
     ) -> Result<()>;
     fn clean(&self, contracts: &[Contract], signal: &Signal) -> Result<()>;
 }

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -23,6 +23,12 @@ pub trait Recipe {
         signal: &Signal,
     ) -> Result<()>;
     fn run(&self, contract: &Contract, build_cmd: String, signal: &Signal) -> Result<()>;
-    fn run_build(&self, contract: &Contract, config: BuildConfig, signal: &Signal) -> Result<()>;
+    fn run_build(
+        &self,
+        contract: &Contract,
+        config: BuildConfig,
+        signal: &Signal,
+        opt_cmd: Option<Vec<String>>,
+    ) -> Result<()>;
     fn clean(&self, contracts: &[Contract], signal: &Signal) -> Result<()>;
 }

--- a/src/recipe/rust.rs
+++ b/src/recipe/rust.rs
@@ -182,13 +182,25 @@ impl Recipe for Rust {
     }
 
     /// build contract
-    fn run_build(&self, contract: &Contract, config: BuildConfig, signal: &Signal) -> Result<()> {
+    fn run_build(
+        &self,
+        contract: &Contract,
+        config: BuildConfig,
+        signal: &Signal,
+        opt_cmd: Option<Vec<String>>,
+    ) -> Result<()> {
         // docker cargo build
         let mut rel_bin_path = PathBuf::new();
         let (bin_dir_prefix, build_cmd_opt) = match config.build_env {
             BuildEnv::Debug => ("debug", ""),
             BuildEnv::Release => ("release", "--release"),
         };
+        let mut build_cmd_opt = String::from(build_cmd_opt);
+        if opt_cmd.is_some() {
+            for cmd in opt_cmd.unwrap() {
+                build_cmd_opt = build_cmd_opt + " " + &cmd;
+            }
+        }
         rel_bin_path.push(format!(
             "target/{}/{}/{}",
             RUST_TARGET, bin_dir_prefix, &contract.name

--- a/src/recipe/rust.rs
+++ b/src/recipe/rust.rs
@@ -177,6 +177,7 @@ impl Recipe for Rust {
         ))
         .fix_dir_permission("/code/target".to_string())
         .fix_dir_permission("/code/Cargo.lock".to_string());
+        let cmd = cmd.host_network(self.context.use_docker_host);
         cmd.run(build_cmd, &signal)?;
         Ok(())
     }

--- a/src/recipe/rust.rs
+++ b/src/recipe/rust.rs
@@ -188,7 +188,7 @@ impl Recipe for Rust {
         contract: &Contract,
         config: BuildConfig,
         signal: &Signal,
-        opt_cmd: Option<Vec<String>>,
+        build_args_opt: Option<Vec<String>>,
     ) -> Result<()> {
         // docker cargo build
         let mut rel_bin_path = PathBuf::new();
@@ -196,12 +196,11 @@ impl Recipe for Rust {
             BuildEnv::Debug => ("debug", ""),
             BuildEnv::Release => ("release", "--release"),
         };
-        let mut build_cmd_opt = String::from(build_cmd_opt);
-        if opt_cmd.is_some() {
-            for cmd in opt_cmd.unwrap() {
-                build_cmd_opt = build_cmd_opt + " " + &cmd;
-            }
-        }
+        let build_cmd_opt = if build_args_opt.is_some() {
+            format!("{} {}", build_cmd_opt, build_args_opt.unwrap().join(" "))
+        } else {
+            String::from(build_cmd_opt)
+        };
         rel_bin_path.push(format!(
             "target/{}/{}/{}",
             RUST_TARGET, bin_dir_prefix, &contract.name

--- a/src/util/docker.rs
+++ b/src/util/docker.rs
@@ -67,7 +67,13 @@ impl DockerCommand {
             daemon: false,
             tty: false,
             workdir: "/code".to_string(),
-            inherited_env: vec!["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY"],
+            inherited_env: vec![
+                "HTTP_PROXY",
+                "http_proxy",
+                "HTTPS_PROXY",
+                "https_proxy",
+                "ALL_PROXY",
+            ],
         }
     }
 

--- a/src/util/docker.rs
+++ b/src/util/docker.rs
@@ -67,7 +67,7 @@ impl DockerCommand {
             daemon: false,
             tty: false,
             workdir: "/code".to_string(),
-            inherited_env: vec!["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"],
+            inherited_env: vec!["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY"],
         }
     }
 

--- a/src/util/docker.rs
+++ b/src/util/docker.rs
@@ -201,7 +201,7 @@ impl DockerCommand {
         for key in inherited_env {
             if let Ok(value) = env::var(key) {
                 debug!("inherited env {}={}", key, value);
-                cmd.arg(format!("-e{}:{}", key, value));
+                cmd.arg(format!("-e{}={}", key, value));
             }
         }
 

--- a/templates/rust/tests/Cargo-manifest.toml
+++ b/templates/rust/tests/Cargo-manifest.toml
@@ -6,4 +6,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tentacle-multiaddr = "=0.3.0"
+tentacle-secio = "=0.5.0"
 ckb-testtool = "0.6"


### PR DESCRIPTION
Support http proxy when using subcommand "build"

1. Added for calsule - used to pass to cargo to control more parameters.
2. Add --host parameter to control the [network mode](https://docs.docker.com/network/) of docker. 
3. Fix Fix the problem of http_proxy environment variable incoming.