### PR TITLE
Update docker image to support aarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ checksum = "8b3b72a38c9920a29990df12002c4d069a147c8782f0c211f8a01b2df8f42bfd"
 
 [[package]]
 name = "ckb-capsule"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-capsule"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Nervos Network"]
 edition = "2018"
 license = "MIT"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM nervos/ckb-riscv-gnu-toolchain@sha256:994fbf92e0372a28f7aec4ebea75315e3ebcf2ed7a5e95520aab903ae8cfd21c
+FROM nervos/ckb-riscv-gnu-toolchain:bionic-20211214
 
 # Install Rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2021-08-16 -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2021-12-25 -y
 ENV PATH=/root/.cargo/bin:$PATH
 # Install RISC-V target
 RUN rustup target add riscv64imac-unknown-none-elf
@@ -9,6 +9,6 @@ RUN rustup target add riscv64imac-unknown-none-elf
 RUN cargo install --git https://github.com/nervosnetwork/ckb-binary-patcher.git --rev 930f0b468a8f426ebb759d9da735ebaa1e2f98ba
 # Install CKB debugger
 RUN git clone https://github.com/nervosnetwork/ckb-standalone-debugger.git \
-    && cd ckb-standalone-debugger && git checkout 0.20.0-rc3 && cd - \
-    && cargo install --path ckb-standalone-debugger/bins \
+    && cd ckb-standalone-debugger && git checkout f2df7e54e0cfabadf77cabeb09d202635412f1c8 && cd - \
+    && cargo install --path ckb-standalone-debugger/bins --locked \
     && rm -r ckb-standalone-debugger

--- a/src/recipe/rust.rs
+++ b/src/recipe/rust.rs
@@ -14,7 +14,7 @@ use tera;
 use std::fs;
 use std::path::PathBuf;
 
-pub const DOCKER_IMAGE: &str = "thewawar/ckb-capsule:2021-08-16";
+pub const DOCKER_IMAGE: &str = "thewawar/ckb-capsule:2021-12-25";
 const RUST_TARGET: &str = "riscv64imac-unknown-none-elf";
 const CARGO_CONFIG_PATH: &str = ".cargo/config";
 const BASE_RUSTFLAGS: &str =

--- a/templates/capsule.toml
+++ b/templates/capsule.toml
@@ -2,8 +2,8 @@
 # # path of rust contracts workspace directory,
 # # a `Cargo.toml` file is expected under the directory.
 # workspace_dir = "."
-# toolchain = "nightly-2021-08-16"
-# docker_image = "thewawar/ckb-capsule:2021-08-16"
+# toolchain = "nightly-2021-12-25"
+# docker_image = "thewawar/ckb-capsule:2021-12-25"
 
 # capsule version
 version = "{{ version }}"

--- a/templates/rust/contract/src/main.rs
+++ b/templates/rust/contract/src/main.rs
@@ -6,7 +6,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(asm)]
+#![feature(asm_sym)]
 #![feature(lang_items)]
 #![feature(alloc_error_handler)]
 #![feature(panic_info_message)]
@@ -15,6 +15,7 @@
 mod entry;
 mod error;
 
+use core::arch::asm;
 use ckb_std::{
     default_alloc,
 };

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
         path.push("tmp");
         path
     };
-    fs::create_dir(&tmp_dir).expect("create dir");
+    fs::create_dir_all(&tmp_dir).expect("create dir");
 
     // test cases
     test_build(&tmp_dir, &bin_path, "rust-demo", "rust").expect("rust demo");
@@ -57,7 +57,7 @@ fn test_build<P: AsRef<Path>>(
     env::set_current_dir(&contract_path)?;
     let exit_code = Command::new("bash")
         .arg("-c")
-        .arg(format!("{} build", bin_path))
+        .arg(format!("{} build --host", bin_path))
         .spawn()?
         .wait()?;
     if !exit_code.success() {
@@ -66,7 +66,7 @@ fn test_build<P: AsRef<Path>>(
     println!("Run contract test ...");
     let exit_code = Command::new("bash")
         .arg("-c")
-        .arg(format!("{} test", bin_path))
+        .arg(format!("cargo test -p tests"))
         .spawn()?
         .wait()?;
     if !exit_code.success() {
@@ -110,7 +110,7 @@ fn test_build_sharedlib<P: AsRef<Path>>(
     env::set_current_dir(&contract_path)?;
     let exit_code = Command::new("bash")
         .arg("-c")
-        .arg(format!("{} build", bin_path))
+        .arg(format!("{} build --host", bin_path))
         .spawn()?
         .wait()?;
     if !exit_code.success() {


### PR DESCRIPTION
* Update docker image to support aarch64
* Bump up capsule version to 0.7.2

NOTE: since Rust  inline `asm` is stabilized, contract code `main.rs` should be adjusted.