### PR TITLE
fix: compatibility with newer ckb-cli

### DIFF
--- a/src/bin/capsule.rs
+++ b/src/bin/capsule.rs
@@ -20,7 +20,9 @@ use ckb_capsule::signal;
 use ckb_capsule::tester::Tester;
 use ckb_capsule::version::Version;
 use ckb_capsule::wallet::cli_types::HumanCapacity;
-use ckb_capsule::wallet::{Address, Wallet, DEFAULT_CKB_CLI_BIN_NAME, DEFAULT_CKB_RPC_URL};
+use ckb_capsule::wallet::{
+    Address, Wallet, DEFAULT_CKB_CLI_BIN_NAME, DEFAULT_CKB_INDEXER_RPC_URL, DEFAULT_CKB_RPC_URL,
+};
 use ckb_testtool::ckb_types::core::Capacity;
 
 use clap::{App, AppSettings, Arg, SubCommand};
@@ -130,7 +132,16 @@ fn run_cli() -> Result<()> {
                         .help("Use previously deployed cells as inputs.").possible_values(&["on", "off"]).default_value("on").takes_value(true),
                     Arg::with_name("api")
                         .long("api")
-                        .help("CKB RPC url").default_value(DEFAULT_CKB_RPC_URL).takes_value(true),
+                        .help("CKB RPC url")
+                        .env("API_URL")
+                        .default_value(DEFAULT_CKB_RPC_URL)
+                        .takes_value(true),
+                    Arg::with_name("ckb-indexer-url")
+                        .long("ckb-indexer-url")
+                        .help("ckb-indexer RPC url")
+                        .default_value(DEFAULT_CKB_INDEXER_RPC_URL)
+                        .env("CKB_INDEXER_URL")
+                        .takes_value(true),
                     Arg::with_name("ckb-cli")
                         .long("ckb-cli")
                         .help("CKB cli binary").default_value(DEFAULT_CKB_CLI_BIN_NAME).takes_value(true),
@@ -366,8 +377,14 @@ fn run_cli() -> Result<()> {
             };
             let context = Context::load()?;
             let ckb_rpc_url = args.value_of("api").expect("api");
+            let ckb_indexer_rpc_url = args.value_of("ckb-indexer-url").expect("indexer url");
             let ckb_cli_bin = args.value_of("ckb-cli").expect("ckb-cli");
-            let wallet = Wallet::load(ckb_rpc_url.to_string(), ckb_cli_bin.to_string(), address);
+            let wallet = Wallet::load(
+                ckb_rpc_url.to_string(),
+                ckb_indexer_rpc_url.to_string(),
+                ckb_cli_bin.to_string(),
+                address,
+            );
             let deploy_env: DeployEnv = args
                 .value_of("env")
                 .expect("deploy env")

--- a/src/wallet/cli_types/live_cell_info.rs
+++ b/src/wallet/cli_types/live_cell_info.rs
@@ -7,10 +7,6 @@ use std::str::FromStr;
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct LiveCellInfoVec {
     pub live_cells: Vec<LiveCellInfo>,
-    pub current_capacity: String,
-    pub current_count: usize,
-    pub total_capacity: String,
-    pub total_count: usize,
 }
 
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]

--- a/src/wallet/collector.rs
+++ b/src/wallet/collector.rs
@@ -9,13 +9,15 @@ pub struct Collector {
     locked_cells: HashSet<OutPoint>,
     ckb_cli_bin: String,
     api_uri: String,
+    indexer_uri: String,
 }
 
 impl Collector {
-    pub fn new(api_uri: String, ckb_cli_bin: String) -> Self {
+    pub fn new(api_uri: String, indexer_uri: String, ckb_cli_bin: String) -> Self {
         Collector {
             locked_cells: HashSet::default(),
             api_uri,
+            indexer_uri,
             ckb_cli_bin,
         }
     }
@@ -85,8 +87,9 @@ impl Collector {
             Command::new(&self.ckb_cli_bin)
                 .arg("--url")
                 .arg(&self.api_uri)
+                .arg("--ckb-indexer-url")
+                .arg(&self.indexer_uri)
                 .arg("rpc")
-                .arg("--wait-for-sync")
                 .arg("get_tip_block_number")
                 .arg("--output-format")
                 .arg("json")
@@ -113,8 +116,9 @@ impl Collector {
             Command::new(&self.ckb_cli_bin)
                 .arg("--url")
                 .arg(&self.api_uri)
+                .arg("--ckb-indexer-url")
+                .arg(&self.indexer_uri)
                 .arg("wallet")
-                .arg("--wait-for-sync")
                 .arg("get-live-cells")
                 .arg("--address")
                 .arg(address.display_with_network(address.network()))

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -21,10 +21,12 @@ use std::process::{Command, Stdio};
 
 pub const DEFAULT_CKB_CLI_BIN_NAME: &str = "ckb-cli";
 pub const DEFAULT_CKB_RPC_URL: &str = "http://localhost:8114";
+pub const DEFAULT_CKB_INDEXER_RPC_URL: &str = "http://localhost:8116";
 
 pub struct Wallet {
     ckb_cli_bin: String,
     api_uri: String,
+    indexer_uri: String,
     rpc_client: RpcClient,
     address: Address,
     genesis: BlockView,
@@ -32,13 +34,14 @@ pub struct Wallet {
 }
 
 impl Wallet {
-    pub fn load(uri: String, ckb_cli_bin: String, address: Address) -> Self {
+    pub fn load(uri: String, indexer_uri: String, ckb_cli_bin: String, address: Address) -> Self {
         let rpc_client = RpcClient::new(&uri);
         let genesis = rpc_client.get_block_by_number(0u64).expect("genesis");
-        let collector = Collector::new(uri.clone(), ckb_cli_bin.clone());
+        let collector = Collector::new(uri.clone(), indexer_uri.clone(), ckb_cli_bin.clone());
         Wallet {
             ckb_cli_bin,
             api_uri: uri,
+            indexer_uri,
             rpc_client,
             address,
             genesis: genesis.into(),
@@ -164,6 +167,8 @@ impl Wallet {
             .stdout(Stdio::piped())
             .arg("--url")
             .arg(&self.api_uri)
+            .arg("--ckb-indexer-url")
+            .arg(&self.indexer_uri)
             .arg("util")
             .arg("sign-message")
             .arg("--recoverable")


### PR DESCRIPTION
- Remove --wait-for-sync arg when calling ckb-cli
- Remove fields that no longer exists in LiveCellInfoVec
