### PR TITLE
chore: 🤖 Remove ckb-indexer-url parameter for ckb-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "8b3b72a38c9920a29990df12002c4d069a147c8782f0c211f8a01b2df8f42bfd"
 
 [[package]]
 name = "ckb-capsule"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "8b3b72a38c9920a29990df12002c4d069a147c8782f0c211f8a01b2df8f42bfd"
 
 [[package]]
 name = "ckb-capsule"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-capsule"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Nervos Network"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-capsule"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Nervos Network"]
 edition = "2021"
 license = "MIT"

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -3,8 +3,6 @@ use log::warn;
 use std::fmt;
 use std::process::{Command, Output};
 
-use crate::wallet::REQUIRED_CKB_CLI_VERSION;
-
 fn check_cmd(program: &str, arg: &str) -> Result<Output> {
     Command::new(program).arg(arg).output().map_err(Into::into)
 }
@@ -74,8 +72,10 @@ impl Checker {
     }
 }
 
+const REQUIRED_CKB_CLI_VERSION: Version = Version(1, 2, 0);
+
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Version(pub usize, pub usize, pub usize);
+struct Version(usize, usize, usize);
 
 impl Version {
     fn parse_with_prefix(prefix: &'static str, buf: Vec<u8>) -> Result<Self> {

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -3,6 +3,8 @@ use log::warn;
 use std::fmt;
 use std::process::{Command, Output};
 
+use crate::wallet::REQUIRED_CKB_CLI_VERSION;
+
 fn check_cmd(program: &str, arg: &str) -> Result<Output> {
     Command::new(program).arg(arg).output().map_err(Into::into)
 }
@@ -13,11 +15,11 @@ pub struct Checker {
 }
 
 impl Checker {
-    pub fn build() -> Result<Self> {
+    pub fn build(ckb_cli_bin: &str) -> Result<Self> {
         let docker = check_cmd("docker", "version")
             .map(|output| output.status.success())
             .unwrap_or(false);
-        let ckb_cli = check_cmd("ckb-cli", "--version")
+        let ckb_cli = check_cmd(ckb_cli_bin, "--version")
             .map(|output| output.stdout)
             .ok();
         Ok(Checker { docker, ckb_cli })
@@ -72,10 +74,8 @@ impl Checker {
     }
 }
 
-const REQUIRED_CKB_CLI_VERSION: Version = Version(0, 34, 0);
-
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-struct Version(usize, usize, usize);
+pub struct Version(pub usize, pub usize, pub usize);
 
 impl Version {
     fn parse_with_prefix(prefix: &'static str, buf: Vec<u8>) -> Result<Self> {

--- a/src/wallet/collector.rs
+++ b/src/wallet/collector.rs
@@ -9,15 +9,13 @@ pub struct Collector {
     locked_cells: HashSet<OutPoint>,
     ckb_cli_bin: String,
     api_uri: String,
-    indexer_uri: String,
 }
 
 impl Collector {
-    pub fn new(api_uri: String, indexer_uri: String, ckb_cli_bin: String) -> Self {
+    pub fn new(api_uri: String, ckb_cli_bin: String) -> Self {
         Collector {
             locked_cells: HashSet::default(),
             api_uri,
-            indexer_uri,
             ckb_cli_bin,
         }
     }
@@ -87,8 +85,6 @@ impl Collector {
             Command::new(&self.ckb_cli_bin)
                 .arg("--url")
                 .arg(&self.api_uri)
-                .arg("--ckb-indexer-url")
-                .arg(&self.indexer_uri)
                 .arg("rpc")
                 .arg("get_tip_block_number")
                 .arg("--output-format")
@@ -116,8 +112,6 @@ impl Collector {
             Command::new(&self.ckb_cli_bin)
                 .arg("--url")
                 .arg(&self.api_uri)
-                .arg("--ckb-indexer-url")
-                .arg(&self.indexer_uri)
                 .arg("wallet")
                 .arg("get-live-cells")
                 .arg("--address")

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -1,5 +1,3 @@
-use crate::checker::Version;
-
 use super::cli_types::{Address, LiveCell, SignatureOutput};
 use super::collector::Collector;
 use super::password::Password;
@@ -21,9 +19,8 @@ use std::collections::HashSet;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
+// If ckb-cli is not compatible anymore, don't forget to update variable REQUIRED_CKB_CLI_VERSION in checker.rs
 pub const DEFAULT_CKB_CLI_BIN_NAME: &str = "ckb-cli";
-// required ckb-cli version, put it here to prevent forget update after ckb-cli is not compatible anymore
-pub const REQUIRED_CKB_CLI_VERSION: Version = Version(1, 2, 0);
 pub const DEFAULT_CKB_RPC_URL: &str = "http://localhost:8114";
 
 pub struct Wallet {


### PR DESCRIPTION
1. Remove `--ckb-indexer-url` for `ckb-cli`;
2. Update REQUIRED_CKB_CLI_VERSION to 1.2.0;
3. Move REQUIRED_CKB_CLI_VERSION to wallet.rs;
4. Use parameter ckb-cli to check version if the parameter provided.
5. Update version to "0.9.0"