### PR TITLE
chore: generate project and contract without using docker

### DIFF
--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -24,7 +24,7 @@ pub trait Recipe {
         contract: &Contract,
         rewrite_config: bool,
         signal: &Signal,
-        docker_env_file: String,
+        env_file: String,
     ) -> Result<()>;
     fn run(&self, contract: &Contract, build_cmd: String, signal: &Signal) -> Result<()>;
     fn run_build(

--- a/src/util/docker.rs
+++ b/src/util/docker.rs
@@ -238,9 +238,8 @@ impl DockerCommand {
         // fix files permission
         shell_cmd.push_str("; EXITCODE=$?");
         for f in &fix_permission_files {
-            shell_cmd.push_str(
-                format!("; test -f {f} -o -d {f} && chown -R $UID:$GID {f}", f = f).as_str(),
-            );
+            log::trace!("[fix permission] file: {}", f);
+            shell_cmd.push_str(format!("; chown -R $UID:$GID {f}").as_str());
         }
         shell_cmd.push_str("; exit $EXITCODE");
         cmd.args(&[docker_image.as_ref(), "bash", "-c", shell_cmd.as_str()]);


### PR DESCRIPTION
Use host cargo to generate projects and contracts. This can reduce our dependence on docker. #84 may remove the docker completely.