### PR TITLE
chore: run 'capsule test' without docker

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,5 +17,7 @@ jobs:
       run: cargo build
     - name: Install dependencies
       run: cargo install --version 0.7.3 moleculec
-    - name: Run tests
-      run: cargo test && cargo run -p tests
+    - name: Cargo test
+      run: cargo test
+    - name: Run integration tests
+      run: bash ./dev-tools/integration-tests.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ members = [
     "tests",
     "crates/testtool",
 ]
+exclude = ["tmp"]

--- a/dev-tools/integration-tests.sh
+++ b/dev-tools/integration-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Prepare test environment..."
+rm -rf tmp/rust-demo/
+
+echo "Running tests..."
+cargo run -p tests
+
+echo "Ok"

--- a/dev-tools/integration-tests.sh
+++ b/dev-tools/integration-tests.sh
@@ -3,6 +3,9 @@
 echo "Prepare test environment..."
 rm -rf tmp/rust-demo/
 
+echo "Build..."
+cargo build
+
 echo "Running tests..."
 cargo run -p tests
 

--- a/src/bin/capsule.rs
+++ b/src/bin/capsule.rs
@@ -114,8 +114,14 @@ fn run_cli() -> Result<()> {
         .args(&[Arg::with_name("name").short("n").long("name").required(true).takes_value(true).help("contract name"),
                 Arg::with_name("cmd").required(true).multiple(true).help("command to run")])
         .display_order(4))
-        .subcommand(SubCommand::with_name("test").about("Run tests").arg(
-                    Arg::with_name("release").long("release").help("Test release mode contracts.")
+        .subcommand(SubCommand::with_name("test").about("Run `cargo test` in the tests directory").arg(
+            Arg::with_name("release").long("release").help("Test release mode contracts.").display_order(1)
+        ).arg(
+            Arg::with_name("testname")
+                .takes_value(true)
+                .value_name("TESTNAME")
+                .help("If specified, only run tests containing this string in their names.")
+                .display_order(2)
         ).display_order(5))
         .subcommand(
             SubCommand::with_name("deploy")
@@ -360,7 +366,8 @@ fn run_cli() -> Result<()> {
             } else {
                 BuildEnv::Debug
             };
-            Tester::run(&context, build_env, &signal, env_file)?;
+            let test_name = args.value_of("testname");
+            Tester::run(&context, build_env, test_name)?;
         }
         ("deploy", Some(args)) => {
             let ckb_cli_bin = args.value_of("ckb-cli").expect("ckb-cli");

--- a/src/project_context.rs
+++ b/src/project_context.rs
@@ -14,7 +14,7 @@ const MIGRATIONS_DIR: &str = "migrations";
 pub const CONFIG_FILE: &str = "capsule.toml";
 pub const CARGO_CONFIG_FILE: &str = "Cargo.toml";
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BuildEnv {
     Debug,
     Release,

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -23,13 +23,11 @@ impl Tester {
             cmd.arg(test_name);
         }
         cmd.arg("--").arg("--nocapture");
-        let output = cmd.output()?;
-        if output.status.success() {
-            println!("{}", String::from_utf8(output.stdout)?);
-        } else {
+        let status = cmd.status()?;
+        if !status.success() {
             return Err(anyhow::anyhow!(
-                "cargo test failed: \n{}",
-                String::from_utf8(output.stderr)?
+                "cargo test failed: {}",
+                status.code().unwrap_or(-1)
             ));
         }
         Ok(())

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -1,24 +1,25 @@
 use std::process::Command;
 
 use crate::project_context::{BuildEnv, Context};
-use crate::recipe::rust::DOCKER_IMAGE;
-use crate::signal::Signal;
-use crate::util::docker::DockerCommand;
 use anyhow::Result;
 
+const TEST_ENV_VAR: &str = "CAPSULE_TEST_ENV";
 const TESTS_DIR: &str = "tests";
 pub struct Tester;
 
 impl Tester {
     pub fn run(project_context: &Context, env: BuildEnv, test_name: Option<&str>) -> Result<()> {
+        let env_arg = match env {
+            BuildEnv::Debug => "debug",
+            BuildEnv::Release => "release",
+        };
         let workspace_dir = project_context.workspace_dir()?;
         let test_dir = workspace_dir.join(TESTS_DIR);
         // When workspace_dir is "contracts" we must mount build directory to /code/build so that test Loader can load the binary.
         let mut cmd = Command::new("cargo");
-        cmd.arg("test").current_dir(&test_dir);
-        if env == BuildEnv::Release {
-            cmd.arg("--release");
-        }
+        cmd.arg("test")
+            .current_dir(&test_dir)
+            .env(TEST_ENV_VAR, env_arg);
         if let Some(test_name) = test_name {
             cmd.arg(test_name);
         }

--- a/templates/Cargo-manifest.toml
+++ b/templates/Cargo-manifest.toml
@@ -1,5 +1,6 @@
 [workspace]
-members = ["tests"]
+members = []
+exclude = ["tests"]
 
 [profile.release]
 overflow-checks = true

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -53,7 +53,10 @@ fn test_build<P: AsRef<Path>>(
         .arg(template_type)
         .output()?;
     if !output.status.success() {
-        panic!("command crash, stderr {:?}", String::from_utf8(output.stderr)?);
+        panic!(
+            "command crash, stderr {:?}",
+            String::from_utf8(output.stderr)?
+        );
     }
     println!("Building ...");
     env::set_current_dir(&contract_path)?;

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -46,15 +46,14 @@ fn test_build<P: AsRef<Path>>(
     contract_path.push(&dir);
     contract_path.push(name);
     println!("Creating {:?} ...", contract_path);
-    let exit_code = Command::new(bin_path)
+    let output = Command::new(bin_path)
         .arg("new")
         .arg(name)
         .arg("--template")
         .arg(template_type)
-        .spawn()?
-        .wait()?;
-    if !exit_code.success() {
-        panic!("command crash, exit_code {:?}", exit_code.code());
+        .output()?;
+    if !output.status.success() {
+        panic!("command crash, stderr {:?}", String::from_utf8(output.stderr)?);
     }
     println!("Building ...");
     env::set_current_dir(&contract_path)?;
@@ -69,7 +68,7 @@ fn test_build<P: AsRef<Path>>(
     println!("Run contract test ...");
     let exit_code = Command::new("bash")
         .arg("-c")
-        .arg(format!("cargo test -p tests"))
+        .arg(format!("capsule test"))
         .spawn()?
         .wait()?;
     if !exit_code.success() {


### PR DESCRIPTION
Replace #31 

1. Exclude the `tests` crate in the cargo workspace.
    1. contracts may need to reference other contracts. Putting them in the same workspace simplifies this.
3. Run `capsule test` without docker.
    1. The trailing style args do not work with the clap 2.33.x, we should support it after upgrading the clap.