### PR TITLE
chore: bump v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com).
 
+## [v0.9.2] - 2023-04-24
+
+Misc:
+
+* chore: generate project and contract without using docker #91
+* chore: run 'capsule test' without docker #96
+* chore: update README #98
+* chore(ci): build binaries on ubuntu-20.04 #102
+
+Full Changelog: https://github.com/nervosnetwork/capsule/compare/v0.9.1...v0.9.2
+
 ## [v0.9.1] - 2023-04-18
 
 Features:
@@ -15,4 +26,4 @@ Misc:
 * chore: remove dependency simple-jsonrpc-client and update reqwest #83
 * chore: add ckb-testtool to capsule repository #90
 
-Full Changelog: https://github.com/nervosnetwork/capsule/compare/v0.9.0...develop
+Full Changelog: https://github.com/nervosnetwork/capsule/compare/v0.9.0...v0.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ checksum = "8b3b72a38c9920a29990df12002c4d069a147c8782f0c211f8a01b2df8f42bfd"
 
 [[package]]
 name = "ckb-capsule"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "ckb-capsule"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Nervos Network"]
 edition = "2021"
 license = "MIT"
-description = "Capsule is a development framework for creating smart contract for Nervos' CKB layer 1 blockchain."
+description = "Capsule is a development framework for creating smart contract for Nervos' CKB."
 homepage = "https://github.com/nervosnetwork/capsule"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ CKB supports several programming languages for writing scripts, and the language
 
 The following must be installed and available to use Capsule.
 
-- Docker - Capsule uses `docker` to build contracts and run tests. https://docs.docker.com/get-docker/
+- cargo - Capsule uses `cargo` to generate Rust contracts and run tests.
+- docker - Capsule uses `docker` container to reproducible build contracts. https://docs.docker.com/get-docker/
 - ckb-cli (optional) - Capsule requires `ckb-cli` to enable the smart contract deployment feature. https://github.com/nervosnetwork/ckb-cli/releases
 
 Note: Docker and ckb-cli must be accessible in the `PATH` in order for them to be used by Capsule.

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -8,19 +8,27 @@ fn check_cmd(program: &str, arg: &str) -> Result<Output> {
 }
 
 pub struct Checker {
-    pub docker: bool,
-    pub ckb_cli: Option<Vec<u8>>,
+    cargo: bool,
+    docker: bool,
+    ckb_cli: Option<Vec<u8>>,
 }
 
 impl Checker {
     pub fn build(ckb_cli_bin: &str) -> Result<Self> {
+        let cargo = check_cmd("cargo", "version")
+            .map(|output| output.status.success())
+            .unwrap_or(false);
         let docker = check_cmd("docker", "version")
             .map(|output| output.status.success())
             .unwrap_or(false);
         let ckb_cli = check_cmd(ckb_cli_bin, "--version")
             .map(|output| output.stdout)
             .ok();
-        Ok(Checker { docker, ckb_cli })
+        Ok(Checker {
+            cargo,
+            docker,
+            ckb_cli,
+        })
     }
 
     pub fn check_ckb_cli(&self) -> Result<()> {
@@ -45,6 +53,13 @@ impl Checker {
 
     pub fn print_report(&self) {
         println!("------------------------------");
+        if self.cargo {
+            println!("cargo\tinstalled");
+        } else {
+            println!(
+                "cargo\tnot found - Please install rust (https://www.rust-lang.org/tools/install)"
+            );
+        }
         if self.docker {
             println!("docker\tinstalled");
         } else {


### PR DESCRIPTION
## [v0.9.2] - 2023-04-24

Misc:

* chore: generate project and contract without using docker #91
* chore: run 'capsule test' without docker #96
* chore: update README #98
* chore(ci): build binaries on ubuntu-20.04 #102

Full Changelog: https://github.com/nervosnetwork/capsule/compare/v0.9.1...develop