### PR TITLE
fix: fix templates gitignore file by ignore all target folder

### DIFF
--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -2,6 +2,7 @@
 target/*
 .cache/.cargo/*
 contracts/**/target/*
+tests/target/*
 
 # C
 contracts/c/build/*

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,8 +1,6 @@
 # Rust
-target/*
+target
 .cache/.cargo/*
-contracts/**/target/*
-tests/target/*
 
 # C
 contracts/c/build/*


### PR DESCRIPTION
I use Capsule 0.9.2. After I finished the `capsule test`, I found that the `tests/target/*` path needs to be put into the gitignore file.