### PR TITLE
feat: supports different test cwd

### DIFF
--- a/templates/rust/tests/src/lib.rs
+++ b/templates/rust/tests/src/lib.rs
@@ -46,9 +46,16 @@ impl Loader {
         };
         let dir = env::current_dir().unwrap();
         let mut base_path = PathBuf::new();
-        base_path.push(dir);
-        base_path.push("..");
+        // cargo may use a different cwd when running tests, for example:
+        // when running debug in vscode, it will use workspace root as cwd by default,
+        // when running test by `cargo test`, it will use tests directory as cwd,
+        // so we need a fallback path
         base_path.push("build");
+        if !base_path.exists() {
+            base_path.pop();
+            base_path.push("..");
+            base_path.push("build");
+        }
         base_path.push(load_prefix);
         Loader(base_path)
     }


### PR DESCRIPTION
With this PR we can run debugger in vscode to debug the rust contract with default configuration:

<img width="749" alt="Screenshot 2023-05-15 at 16 53 12" src="https://github.com/nervosnetwork/capsule/assets/8990/2bfc644a-685c-4167-be4d-ab094cfedb92">
