### PR TITLE
release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com).
 
+## [v0.10.1] - 2023-06-19
+
+Bug fixes:
+
+* fix: fix address parsing #125
+* feat: remap path prefixs on release #122
+
+Misc:
+
+* Upgrade ckb-std and ckb-testtool dependencies
+
+
+CKB Testtool:
+
+* feat(ckb-testtool): Support Type ID #123
+
+
+Full Changelog: https://github.com/nervosnetwork/capsule/compare/v0.10.0...v0.10.1
+
 ## [v0.10.0] - 2023-05-08
 
 Capsule now uses `cross` to manage Rust contracts building. You can learn more details about this change in issue [#106](https://github.com/nervosnetwork/capsule/pull/106), and the wiki page [Upgrade an existing project to capsule 0.10](https://github.com/nervosnetwork/capsule/wiki/Upgrade-an-existing-project-to-capsule-0.10) provides instructions for upgrading an existing project to capsule `v0.10.0`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
  "atty",
  "chrono",
  "ckb-sdk",
- "ckb-testtool 0.9.0",
+ "ckb-testtool 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap",
  "ctrlc",
  "env_logger",
@@ -535,9 +535,7 @@ checksum = "243197680f69d6bb6cb1caf16199ce4a8162a258c757d5af8f727af0d8aabe9e"
 
 [[package]]
 name = "ckb-testtool"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15fed7e8aeb21e981246bc39e0bd49067f7734851798bef996389a3b02bf9b4e"
+version = "0.9.1"
 dependencies = [
  "ckb-always-success-script",
  "ckb-chain-spec",
@@ -551,12 +549,14 @@ dependencies = [
  "ckb-types",
  "ckb-verification",
  "lazy_static",
- "rand 0.7.3",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "ckb-testtool"
 version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ed676eb4411676d2e507067a714905fea8842ba2e0c0ac5ede68fe350b5547"
 dependencies = [
  "ckb-always-success-script",
  "ckb-chain-spec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "8b3b72a38c9920a29990df12002c4d069a147c8782f0c211f8a01b2df8f42bfd"
 
 [[package]]
 name = "ckb-capsule"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 tera = "1.2"
 lazy_static = "1.4"
 serde = { version = "1.0", features = [ "derive" ] }
-ckb-testtool = "0.9.0"
+ckb-testtool = "0.9.1"
 secp256k1 = "0.24"
 serde_json = "1.0"
 rpassword = "4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-capsule"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Nervos Network"]
 edition = "2021"
 license = "MIT"

--- a/crates/tests/test-contract/Cargo.lock
+++ b/crates/tests/test-contract/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "blake2b-ref"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "294d17c72e0ba59fad763caa112368d0672083779cdebbb97164f4bb4c1e339a"
+
+[[package]]
 name = "buddy-alloc"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,19 +28,20 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ckb-standalone-types"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d7cbbdab96e6b809a102cf88bfec28795a0a3c06bfdea4abe4de89777801cd"
+checksum = "acafe9a1a706e9704a3c37cdc05fddb84cf991fb0744df21e5a0d91e128163b8"
 dependencies = [
+ "blake2b-ref",
  "cfg-if",
  "molecule",
 ]
 
 [[package]]
 name = "ckb-std"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dbb4cafeca131457738f8428ef31a7729f7914b99b5c210554433f03eb2f936"
+checksum = "ef02519ff65a2326e0ce8d3b4920c7dedac28f79eee4d7aef3ce64fccb556710"
 dependencies = [
  "buddy-alloc",
  "cc",

--- a/crates/tests/test-contract/contracts/test-contract/Cargo.toml
+++ b/crates/tests/test-contract/contracts/test-contract/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "test-contract"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-std = "0.12.1"
+ckb-std = "0.14.0"

--- a/crates/tests/test-contract/tests/Cargo.toml
+++ b/crates/tests/test-contract/tests/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "tests"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-testtool = "0.7.1"
+ckb-testtool = { path = "../testtool" }

--- a/templates/rust/contract/Cargo-manifest.toml
+++ b/templates/rust/contract/Cargo-manifest.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-std = "0.13"
+ckb-std = "0.14.0"


### PR DESCRIPTION
## [v0.10.1] - 2023-06-19

Bug fixes:

* fix: fix address parsing #125
* feat: remap path prefixs on release #122

Misc:

* Upgrade ckb-std and ckb-testtool dependencies


CKB Testtool:

* feat(ckb-testtool): Support Type ID #123