### PR TITLE
feat: build_script using ScriptHashType::Type

### DIFF
--- a/crates/testtool/src/context.rs
+++ b/crates/testtool/src/context.rs
@@ -200,10 +200,10 @@ impl Context {
                 .build(),
         )
     }
-    /// Build script with out_point, args (hash_type = ScriptHashType::Data1)
+    /// Build script with out_point, args and hash_type(ScriptHashType::Type)
     /// return none if the out-point is not exist
     pub fn build_script(&mut self, out_point: &OutPoint, args: Bytes) -> Option<Script> {
-        self.build_script_with_hash_type(out_point, ScriptHashType::Data1, args)
+        self.build_script_with_hash_type(out_point, ScriptHashType::Type, args)
     }
 
     fn find_cell_dep_for_script(&self, script: &Script) -> CellDep {


### PR DESCRIPTION
This PR changes script_hash in `build_script` from `Data1` to `Type`.

Users should assume `build_script` always return a script run on the newest VM. To use a specific version, they must explicitly pass `Datax` hash_type to `build_script_with_hash_type`.