### PR TITLE
chore: version v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com).
 
+## [v0.10.2] - 2023-11-3
+
+Misc:
+
+* chore: upgrade to ckb v0.111
+
 ## [v0.10.1] - 2023-06-19
 
 Bug fixes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "8b3b72a38c9920a29990df12002c4d069a147c8782f0c211f8a01b2df8f42bfd"
 
 [[package]]
 name = "ckb-capsule"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-capsule"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Nervos Network"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
## [v0.10.2] - 2023-11-3

Misc:

* chore: upgrade to ckb v0.111