### PR TITLE
update Cargo.toml in generated rust project

### DIFF
--- a/templates/Cargo-manifest.toml
+++ b/templates/Cargo-manifest.toml
@@ -1,6 +1,5 @@
 [workspace]
-members = []
-exclude = ["tests"]
+members = ["tests"]
 
 [profile.release]
 overflow-checks = true


### PR DESCRIPTION
the default resolver version is 2 after rust 1.54, we may include the `tests` in the workspace member by default now.

ref: https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
