### PR TITLE
chore: bump capsule 0.10.3, ckb-testtool 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com).
 
+## [v0.10.3] - 2024-01-4
+
+Capsule:
+
+* chore: deprecate deploy #139
+
+CKB Testtool(v0.10.1):
+
+* upgrade rust-toolchain in generated rust project #135
+* update Cargo.toml in generated rust project #136
+* feat: Add utility function to dump tx as MockTransaction format #137
+
+Full Changelog: https://github.com/nervosnetwork/capsule/compare/v0.10.2...v0.10.3
+
 ## [v0.10.2] - 2023-11-3
 
 Misc:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,13 +199,13 @@ checksum = "8b3b72a38c9920a29990df12002c4d069a147c8782f0c211f8a01b2df8f42bfd"
 
 [[package]]
 name = "ckb-capsule"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "atty",
  "chrono",
  "ckb-sdk",
- "ckb-testtool 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-testtool 0.10.0",
  "clap",
  "ctrlc",
  "env_logger",
@@ -567,6 +567,8 @@ checksum = "d5c03dd01263a66eaf171fb1bbadd12d80a0b54abe19aa55a2c53c5ae3300cda"
 [[package]]
 name = "ckb-testtool"
 version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f7426eb44c6cfc703a68fb99c74b675a378fdca12df5af94683b27a60d377e"
 dependencies = [
  "ckb-always-success-script",
  "ckb-chain-spec",
@@ -574,7 +576,6 @@ dependencies = [
  "ckb-error",
  "ckb-hash",
  "ckb-jsonrpc-types",
- "ckb-mock-tx-types",
  "ckb-resource",
  "ckb-script",
  "ckb-traits",
@@ -586,9 +587,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-testtool"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f7426eb44c6cfc703a68fb99c74b675a378fdca12df5af94683b27a60d377e"
+version = "0.10.1"
 dependencies = [
  "ckb-always-success-script",
  "ckb-chain-spec",
@@ -596,6 +595,7 @@ dependencies = [
  "ckb-error",
  "ckb-hash",
  "ckb-jsonrpc-types",
+ "ckb-mock-tx-types",
  "ckb-resource",
  "ckb-script",
  "ckb-traits",
@@ -2535,7 +2535,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ckb-system-scripts",
- "ckb-testtool 0.10.0",
+ "ckb-testtool 0.10.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-capsule"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Nervos Network"]
 edition = "2021"
 license = "MIT"

--- a/crates/testtool/Cargo.toml
+++ b/crates/testtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-testtool"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Nervos Network"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION

## [v0.10.3] - 2024-01-4

Capsule:

* chore: deprecate deploy #139

CKB Testtool(v0.10.1):

* upgrade rust-toolchain in generated rust project #135
* update Cargo.toml in generated rust project #136
* feat: Add utility function to dump tx as MockTransaction format #137

Full Changelog: https://github.com/nervosnetwork/capsule/compare/v0.10.2...v0.10.3