### PR TITLE
chore: upgrade ckb-std to 0.15.3

### DIFF
--- a/crates/tests/test-contract/contracts/test-contract/Cargo.toml
+++ b/crates/tests/test-contract/contracts/test-contract/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-std = "0.15.1"
+ckb-std = "0.15.3"

--- a/templates/rust/contract/Cargo-manifest.toml
+++ b/templates/rust/contract/Cargo-manifest.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-std = "0.15.1"
+ckb-std = "0.15.3"


### PR DESCRIPTION
0.15.1 is with bug, see:
https://github.com/nervosnetwork/ckb-std/commit/bcdab481f0966e341dc533557f8bd6e66cda587b