### PR TITLE
Fix cross commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following must be installed and available to use Capsule.
 - cross. Capsule uses `cross` to build rust contracts. Install with
 
 ```command
-$ cargo install cross --git https://github.com/cross-rs/cross
+$ cargo install cross --git https://github.com/cross-rs/cross --rev=6982b6c
 ```
 
 Note: All commands must be accessible in the `PATH` in order for them to be used by Capsule.


### PR DESCRIPTION
The default cross requires very new Rust version:
```
error: cannot install package `cross 0.2.5`,
it requires rustc 1.77.2 or newer, while the currently active rustc version is 1.75.0
```

